### PR TITLE
Legger til protocol: redis i redis.yml

### DIFF
--- a/redis-config.yml
+++ b/redis-config.yml
@@ -24,3 +24,4 @@ spec:
       memory: 256Mi
   service:
     port: 6379
+    protocol: redis


### PR DESCRIPTION
Dette manglet i yml til Redis. Førte til at api ikke fikk snakke med Redis instansen. Ser ut til å løse problemet 
Jeg har slettet de gamle instansene i dev og prod gcp, og laget nye. Har testet, det fungerer.