### PR TITLE
Øker timeout mot mottak til 60sek. 

### DIFF
--- a/src/main/kotlin/no/nav/omsorgspengerutbetaling/mottak/OmsorgpengesøknadMottakGateway.kt
+++ b/src/main/kotlin/no/nav/omsorgspengerutbetaling/mottak/OmsorgpengesøknadMottakGateway.kt
@@ -65,8 +65,8 @@ class OmsorgpengesøknadMottakGateway(
 
         val httpRequet = komplettUrl
             .httpPost()
-            .timeout(20_000)
-            .timeoutRead(20_000)
+            .timeout(60_000)
+            .timeoutRead(60_000)
             .body(contentStream)
             .header(
                 HttpHeaders.ContentType to "application/json",


### PR DESCRIPTION
Dette fordi mottak kan feile mot k9-dokument og S3, og vi vil ikke at api skal time ut før mottak gjør det.