### PR TITLE
Setter grensen på body-size til 100MB for nginx.

### DIFF
--- a/nais/naiserator.yml
+++ b/nais/naiserator.yml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{namespace}}
   labels:
     team: {{team}}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "100M"
 spec:
   image: {{ image }}
   azure:


### PR DESCRIPTION
Setter en høy grense slik at det er API som gir feilmelding til frontend ved valideringsfeil, og ikke en uforståelig CORS feil