### PR TITLE
Fiks oppslag av søker + pakkeoppgraderinger

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3.0.0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.0.0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3.2.0
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
           cache: 'gradle'
       - name: Test Code
@@ -41,10 +41,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3.0.0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3.0.0
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3.2.0
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
           cache: 'gradle'
       - name: Build JAR

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/java:11
+FROM navikt/java:17
 
 COPY docker-init-scripts/import-apigw-key.sh /init-scripts/20-import-apigw-key.sh
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,23 +1,23 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val dusseldorfKtorVersion = "3.1.6.7-05da1a0"
+val dusseldorfKtorVersion = "3.1.6.8-1a4651d"
 val ktorVersion = ext.get("ktorVersion").toString()
 val mainClass = "no.nav.omsorgspengerutbetaling.AppKt"
 val lettuceVersion = "6.1.8.RELEASE"
-val k9FormatVersion = "5.8.3"
+val k9FormatVersion = "5.8.7"
 val fuelVersion = "2.3.1"
 val kafkaEmbeddedEnvVersion = ext.get("kafkaEmbeddedEnvVersion").toString()
 val kafkaVersion = ext.get("kafkaVersion").toString() // Alligned med version fra kafka-embedded-env
 
 plugins {
-    kotlin("jvm") version "1.6.10"
+    kotlin("jvm") version "1.6.21"
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
 buildscript {
     // Henter ut diverse dependency versjoner, i.e. ktorVersion.
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/05da1a09b4cad3aef489f934078ac8afafe155ae/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/1a4651d10b134e98f5213ad7e34a8210393840f1/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {
@@ -47,7 +47,7 @@ dependencies {
     implementation("org.glassfish:jakarta.el:3.0.4")
 
     // Test
-    testImplementation("com.github.fppt:jedis-mock:1.0.1")
+    testImplementation("com.github.fppt:jedis-mock:1.0.2")
     testImplementation("no.nav.helse:dusseldorf-test-support:$dusseldorfKtorVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion") {
         exclude(group = "org.eclipse.jetty")
@@ -77,16 +77,16 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
 }
 
 tasks.named<KotlinCompile>("compileTestKotlin") {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
 }
 
 tasks.withType<ShadowJar> {
@@ -102,7 +102,7 @@ tasks.withType<ShadowJar> {
 }
 
 tasks.withType<Wrapper> {
-    gradleVersion = "7.3.3"
+    gradleVersion = "7.4.2"
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/no/nav/omsorgspengerutbetaling/soker/SøkerGateway.kt
+++ b/src/main/kotlin/no/nav/omsorgspengerutbetaling/soker/SøkerGateway.kt
@@ -32,7 +32,7 @@ class SøkerGateway (
     suspend fun hentSoker(
         idToken: IdToken,
         callId : CallId
-    ) : SokerOppslagRespons {
+    ) : Søker {
         val sokerUrl = Url.buildURL(
             baseUrl = baseUrl,
             pathParts = listOf("meg"),
@@ -59,13 +59,23 @@ class SøkerGateway (
                 { error -> throw error.throwable(request, logger, "Feil ved henting av søkers personinformasjon")}
             )
         }
-        return oppslagRespons
+        return oppslagRespons.tilSøker(idToken.getNorskIdentifikasjonsnummer())
     }
+
     data class SokerOppslagRespons(
         val aktør_id: String,
         val fornavn: String,
         val mellomnavn: String?,
         val etternavn: String,
         val fødselsdato: LocalDate
-    )
+    ) {
+        fun tilSøker(fødselsnummer: String) = Søker(
+            aktørId = aktør_id,
+            fødselsnummer = fødselsnummer,
+            fødselsdato = fødselsdato,
+            fornavn = fornavn,
+            mellomnavn = mellomnavn,
+            etternavn = etternavn
+        )
+    }
 }

--- a/src/main/kotlin/no/nav/omsorgspengerutbetaling/soker/SøkerService.kt
+++ b/src/main/kotlin/no/nav/omsorgspengerutbetaling/soker/SøkerService.kt
@@ -1,6 +1,5 @@
 package no.nav.omsorgspengerutbetaling.soker
 
-import com.auth0.jwt.JWT
 import no.nav.helse.dusseldorf.ktor.auth.IdToken
 import no.nav.omsorgspengerutbetaling.general.CallId
 
@@ -11,16 +10,7 @@ class SøkerService (
         idToken: IdToken,
         callId: CallId
     ): Søker {
-        val ident: String = JWT.decode(idToken.value).subject ?: throw IllegalStateException("Token mangler 'sub' claim.")
-        return søkerGateway.hentSoker(idToken, callId).tilSøker(ident)
+        return søkerGateway.hentSoker(idToken, callId)
     }
 
-    private fun  SøkerGateway.SokerOppslagRespons.tilSøker(fodselsnummer: String) = Søker(
-        aktørId = aktør_id,
-        fødselsnummer = fodselsnummer,
-        fødselsdato = fødselsdato,
-        fornavn = fornavn,
-        mellomnavn = mellomnavn,
-        etternavn = etternavn
-    )
 }


### PR DESCRIPTION
Bruker idToken.getNorskIdentifikasjonsnummer() for å hente ident til bruker, i stedet for å decode jwt og sjekke subject. Fungerte frem til de flyttet fnr fra sub til pid..

Oppdaterer pakker, k9-format, java, dusseldorf-ktor og actions.
* Closes #127
* Closes #126
* Closes #125
* Closes #124
* Closes #123
* Closes #117